### PR TITLE
Updated the path creation so the drawing happens in one continuous loop, without a second move call

### DIFF
--- a/metaballs/MetaballsView/Metaball.swift
+++ b/metaballs/MetaballsView/Metaball.swift
@@ -55,12 +55,12 @@ struct Metaball: Equatable {
         path.move(to: c1)
         path.addLine(to: blob.p1)
         path.addCurve(to: blob.p3, controlPoint1: blob.h1, controlPoint2: blob.h3)
+        
         path.addLine(to: c2)
         
-        path.move(to: c1)
-        path.addLine(to: blob.p2)
-        path.addCurve(to: blob.p4, controlPoint1: blob.h2, controlPoint2: blob.h4)
-        path.addLine(to: c2)
+        path.addLine(to: blob.p4)
+        path.addCurve(to: blob.p2, controlPoint1: blob.h4, controlPoint2: blob.h2)
+        path.addLine(to: c1)
         
         return path
     }

--- a/metaballs/MetaballsView/MetaballsView.swift
+++ b/metaballs/MetaballsView/MetaballsView.swift
@@ -81,7 +81,6 @@ public final class MetaballsView: UIView {
             let innerList: [CAShapeLayer] = (0..<config.numberOfBalls).map { _ in
                 let layer = CAShapeLayer()
                 layer.fillColor = config.ballColor.cgColor
-                layer.fillRule = .evenOdd
                 self.layer.addSublayer(layer)
                 
                 return layer


### PR DESCRIPTION
First off, awesome project 🎉 

This seemed more efficient and removes the need for `layer.fillRule = .evenOdd`.

Before with `layer.fillRule = .evenOdd` commented out.
<img width="800" alt="Screen Shot 2020-07-12 at 8 16 36 AM" src="https://user-images.githubusercontent.com/395836/87250323-e34db000-c418-11ea-9af6-85bf63797d6a.png">


After, still with `layer.fillRule = .evenOdd` commented out.
<img width="751" alt="Screen Shot 2020-07-12 at 8 17 47 AM" src="https://user-images.githubusercontent.com/395836/87250306-ca44ff00-c418-11ea-9b13-f9eba8b7a2b1.png">
